### PR TITLE
TFA-15/feature: allow fronted to read cookie

### DIFF
--- a/api/src/routers/google_login.py
+++ b/api/src/routers/google_login.py
@@ -41,7 +41,6 @@ async def google_callback(request: Request, response: Response):
     response.set_cookie(
         key="jwt_token",
         value=jwt_token,
-        httponly=True,
         secure=False,
         samesite="Lax",
     )


### PR DESCRIPTION
### **Description**:

This PR removes the http only parameter in the cookie for it to be read by the frontend.

### **Screenshot/Video:**

### **Ticket link:**
[TFA-15](https://cristopherlml3.atlassian.net/jira/software/projects/TFA/boards/1?selectedIssue=TFA-15)

[TFA-15]: https://cristopherlml3.atlassian.net/browse/TFA-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ